### PR TITLE
LRNG: fix 'archrandom' calculation with CONFIG_RANDOM_TRUST_CPU=y

### DIFF
--- a/lrng_es_archrandom.c
+++ b/lrng_es_archrandom.c
@@ -21,7 +21,7 @@
 #ifdef CONFIG_RANDOM_TRUST_CPU
 /* PowerISA defines DARN to deliver at least 0.5 bits of entropy per data bit */
 static u32 archrandom = LRNG_ARCHRANDOM_TRUST_CPU_STRENGTH /
-			IS_ENABLED(CONFIG_PPC) ? 2 : 1;
+			(IS_ENABLED(CONFIG_PPC) ? 2 : 1);
 #else
 static u32 archrandom = LRNG_ARCHRANDOM_DEFAULT_STRENGTH;
 #endif


### PR DESCRIPTION
```
Fix the following build error when CONFIG_RANDOM_TRUST_CPU is set:

drivers/char/lrng/lrng_es_archrandom.c:23:60: error: division by zero is undefined [-Werror,-Wdivision-by-zero]
  CC  [M] drivers/regulator/pv88080-regulator.o
static u32 archrandom = LRNG_ARCHRANDOM_TRUST_CPU_STRENGTH /
                                                           ^
drivers/char/lrng/lrng_es_archrandom.c:23:25: error: initializer element is not a compile-time constant
static u32 archrandom = LRNG_ARCHRANDOM_TRUST_CPU_STRENGTH /
                        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
drivers/char/lrng/lrng_es_archrandom.c:20:44: note: expanded from macro 'LRNG_ARCHRANDOM_TRUST_CPU_STRENGTH'
 #define LRNG_ARCHRANDOM_TRUST_CPU_STRENGTH LRNG_DRNG_SECURITY_STRENGTH_BITS
                                            ^
drivers/char/lrng/lrng_internal.h:22:42: note: expanded from macro 'LRNG_DRNG_SECURITY_STRENGTH_BITS'
 #define LRNG_DRNG_SECURITY_STRENGTH_BITS (LRNG_DRNG_SECURITY_STRENGTH_BYTES * 8)
                                          ^
2 errors generated.

The reason for it is that

LRNG_ARCHRANDOM_TRUST_CPU_STRENGTH / IS_ENABLED(CONFIG_PPC) ? 2 : 1

is being calculated left-to-right as

(LRNG_ARCHRANDOM_TRUST_CPU_STRENGTH / IS_ENABLED(CONFIG_PPC)) ? 2 : 1

and on non-CONFIG_PPC platforms it eventually becomes zero-division.
On PPC, 'archrandom' value is incorrect and always equals 2.
Enclose the divisor in braces to avoid that.

Fixes: c8f438d7981b ("LRNG: Power DARN instruction contains 0.5 bits of entropy")
Signed-off-by: Alexander Lobakin <alobakin@pm.me>
```