### PR TITLE
Use NTRNG min entropy for AIS 20 / 31 version 3.0

### DIFF
--- a/Kconfig
+++ b/Kconfig
@@ -70,20 +70,20 @@ config LRNG_AIS2031_NTG1_SEEDING_STRATEGY
 	default n
 	help
 	  When enabling this option, two entropy sources must
-	  deliver 220 bits of entropy each to consider a DRNG
+	  deliver 240 bits of entropy each to consider a DRNG
 	  as fully seeded. Any two entropy sources can be used
 	  to fulfill this requirement. If specific entropy sources
 	  shall not be capable of contributing to this seeding
 	  strategy, the respective entropy source must be configured
-	  to provide less than 220 bits of entropy.
+	  to provide less than 240 bits of entropy.
 
 	  The strategy is consistent with the requirements for
-	  NTG.1 compliance in German AIS 20/31 draft from 2022
+	  NTG.1 compliance in German AIS 20/31 version 3.0 from 2024
 	  and is only enforced with lrng_es_mgr.ntg1=1.
 
-	  Compliance with German AIS 20/31 from 2011 is always
-	  present when using /dev/random with the flag O_SYNC or
-	  getrandom(2) with GRND_RANDOM.
+	  Compliance with German AIS 20/31 version 2.0 from 2011 is
+	  always present when using /dev/random with the flag O_SYNC
+	  or getrandom(2) with GRND_RANDOM.
 
 	  If unsure, say N.
 

--- a/lrng_definitions.h
+++ b/lrng_definitions.h
@@ -73,7 +73,7 @@
 #define LRNG_INIT_ENTROPY_BITS		32
 
 /* AIS20/31: NTG.1.4 minimum entropy rate for one entropy source*/
-#define LRNG_AIS2031_NPTRNG_MIN_ENTROPY	220
+#define LRNG_AIS2031_NPTRNG_MIN_ENTROPY	240
 
 /*
  * Wakeup value

--- a/lrng_drng_mgr.c
+++ b/lrng_drng_mgr.c
@@ -312,7 +312,7 @@ static u32 lrng_drng_seed_es_nolock(struct lrng_drng *drng, bool init_ops,
 	 * producing data while this is ongoing.
 	 */
 	} while (force_seeding && forced && !drng->fully_seeded &&
-		 num_es_delivered >= (lrng_ntg1_2022_compliant() ? 2 : 1));
+		 num_es_delivered >= (lrng_ntg1_2024_compliant() ? 2 : 1));
 
 	memzero_explicit(&seedbuf, sizeof(seedbuf));
 

--- a/lrng_es_mgr.c
+++ b/lrng_es_mgr.c
@@ -102,9 +102,8 @@ bool lrng_enforce_panic_on_permanent_health_failure(void)
 	return lrng_panic_on_permanent_health_failure;
 }
 
-bool lrng_ntg1_2022_compliant(void)
+bool lrng_ntg1_2024_compliant(void)
 {
-	/* Implies use of /dev/random w/ O_SYNC / getrandom w/ GRND_RANDOM */
 	return ntg1;
 }
 
@@ -228,7 +227,7 @@ static u32 lrng_avail_entropy_thresh(void)
 bool lrng_fully_seeded(bool fully_seeded, u32 collected_entropy,
 		       struct entropy_buf *eb)
 {
-	/* AIS20/31 NTG.1: two entropy sources with each delivering 220 bits */
+	/* AIS20/31 NTG.1: two entropy sources with each delivering 240 bits */
 	if (ntg1) {
 		u32 i, result = 0, ent_thresh = lrng_avail_entropy_thresh();
 
@@ -330,7 +329,7 @@ void lrng_init_ops(struct entropy_buf *eb)
 		return;
 
 	requested_bits = ntg1 ?
-		/* Approximation so that two ES should deliver 220 bits each */
+		/* Approximation so that two ES should deliver 240 bits each */
 		(lrng_avail_entropy() + LRNG_AIS2031_NPTRNG_MIN_ENTROPY) :
 		/* Apply SP800-90C oversampling if applicable */
 		lrng_get_seed_entropy_osr(state->all_online_numa_node_seeded);

--- a/lrng_proc.c
+++ b/lrng_proc.c
@@ -42,7 +42,7 @@ static int lrng_proc_type_show(struct seq_file *m, void *v)
 		 lrng_security_strength(),
 		 numa_drngs,
 		 lrng_sp80090c_compliant() ? "SP800-90C, " : "",
-		 lrng_ntg1_2022_compliant() ? " / 2022" : "",
+		 lrng_ntg1_2024_compliant() ? " / 2024" : "",
 		 lrng_state_min_seeded() ? "true" : "false",
 		 lrng_state_fully_seeded() ? "true" : "false",
 		 lrng_avail_entropy());


### PR DESCRIPTION
The current entropy is set for the draft value 220 which was changed in the [version 3.0 (2024)](https://www.bsi.bund.de/SharedDocs/Downloads/EN/BSI/Certification/Interpretations/AIS_31_Functionality_classes_for_random_number_generators_e_2024.pdf?__blob=publicationFile&v=3) to 240 bits.

I'm not sure if it makes sense to keep option for draft 220. I default to just change it to 240 as 220 was just in the draft. But if you think it makes sense to keep it, I can add this option.