### PR TITLE
Fix some NTG.1 naming and other inconsistencies

### DIFF
--- a/lrng_es_mgr.c
+++ b/lrng_es_mgr.c
@@ -107,9 +107,8 @@ bool lrng_enforce_panic_on_permanent_health_failure(void)
 	return lrng_panic_on_permanent_health_failure;
 }
 
-bool lrng_ntg1_2022_compliant(void)
+bool lrng_ntg1_2024_compliant(void)
 {
-	/* Implies use of /dev/random w/ O_SYNC / getrandom w/ GRND_RANDOM */
 	return ntg1;
 }
 
@@ -246,7 +245,7 @@ static u32 lrng_avail_entropy_thresh(void)
 bool lrng_fully_seeded(bool fully_seeded, u32 collected_entropy,
 		       struct entropy_buf *eb)
 {
-	/* AIS20/31 NTG.1: two entropy sources with each delivering 220 bits */
+	/* AIS20/31 NTG.1: two entropy sources with each delivering 240 bits */
 	if (ntg1) {
 		u32 i, result = 0, ent_thresh = lrng_avail_entropy_thresh();
 
@@ -352,7 +351,7 @@ void lrng_init_ops(struct entropy_buf *eb)
 		return;
 
 	requested_bits = ntg1 ?
-		/* Approximation so that two ES should deliver 220 bits each */
+		/* Approximation so that two ES should deliver 240 bits each */
 		(lrng_avail_entropy() + LRNG_AIS2031_NPTRNG_MIN_ENTROPY) :
 		/* Apply SP800-90C oversampling if applicable */
 		lrng_get_seed_entropy_osr(state->all_online_numa_node_seeded);

--- a/lrng_es_mgr.h
+++ b/lrng_es_mgr.h
@@ -24,7 +24,7 @@ extern struct lrng_es_cb *lrng_es[];
 	for ((ctr) = 0; (ctr) < lrng_ext_es_last; (ctr)++)
 
 bool lrng_enforce_panic_on_permanent_health_failure(void);
-bool lrng_ntg1_2022_compliant(void);
+bool lrng_ntg1_2024_compliant(void);
 bool lrng_pool_all_numa_nodes_seeded_get(void);
 bool lrng_state_min_seeded(void);
 void lrng_debug_report_seedlevel(const char *name);


### PR DESCRIPTION
Looks like my initial [PR](https://github.com/smuellerDD/lrng/pull/38) did not correctly rename lrng_ntg1_2022_compliant to lrng_ntg1_2024_compliant (missed the header declaration) which resulted in further inconsistency (most likely build should be failing as there are calls in https://github.com/smuellerDD/lrng/blob/27098cdb97c157ae5ea4f9303c1d7f617ae16e0f/lrng_proc.c#L45 and https://github.com/smuellerDD/lrng/blob/27098cdb97c157ae5ea4f9303c1d7f617ae16e0f/lrng_drng_mgr.c#L315 for 2024 version but definition is for 2022 version) after https://github.com/smuellerDD/lrng/commit/4fddf4e35d328f8165b4a69d582838b4ff7172dc .  Also not sure why that commit changed 240 to 220 in comments so changed it back and removed the comment that seems to be just for 2011 version.